### PR TITLE
Remove deprecated `std::hash::hash`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
 
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,13 +89,23 @@ impl<S: AsRef<str>> Hash for UniCase<S> {
     }
 }
 
-#[test]
-fn test_case_insensitive() {
-    use std::hash::{hash, SipHasher};
+#[cfg(test)]
+mod test {
+    use super::UniCase;
+    use std::hash::{Hash, Hasher, SipHasher};
 
-    let a = UniCase("foobar");
-    let b = UniCase("FOOBAR");
+    fn hash<T: Hash>(t: &T) -> u64 {
+        let mut s = SipHasher::new();
+        t.hash(&mut s);
+        s.finish()
+    }
 
-    assert_eq!(a, b);
-    assert_eq!(hash::<_, SipHasher>(&a), hash::<_, SipHasher>(&b));
+    #[test]
+    fn test_case_insensitive() {
+        let a = UniCase("foobar");
+        let b = UniCase("FOOBAR");
+
+        assert_eq!(a, b);
+        assert_eq!(hash(&a), hash(&b));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 
 use std::ascii::AsciiExt;
 use std::fmt;
-use std::hash;
+use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
@@ -80,9 +80,9 @@ impl<S: FromStr> FromStr for UniCase<S> {
     }
 }
 
-impl<S: AsRef<str>> hash::Hash for UniCase<S> {
+impl<S: AsRef<str>> Hash for UniCase<S> {
     #[inline]
-    fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
         for byte in self.as_ref().bytes().map(|b| b.to_ascii_lowercase()) {
             hasher.write(&[byte]);
         }


### PR DESCRIPTION
`std::hash::hash` is deprecated since [1.3.0](https://doc.rust-lang.org/std/hash/fn.hash.html), and removed at 1.4.0.
Implement own `hash` in accordance with the [doc](https://doc.rust-lang.org/beta/std/hash) and use it.