### PR TITLE
Support heapsize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,14 @@ build = "build.rs"
 
 [build-dependencies]
 rustc_version = "0.1"
+
+[dependencies.heapsize]
+version = "0.2.0"
+optional = true
+
+[dependencies.heapsize_plugin]
+version = "0.1.2"
+optional = true
+
+[features]
+heap_size = ["heapsize", "heapsize_plugin"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(test, deny(missing_docs))]
 #![cfg_attr(test, deny(warnings))]
+#![cfg_attr(feature = "heap_size", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "heap_size", plugin(heapsize_plugin))]
 
 //! # Case
 //!
@@ -16,6 +18,9 @@
 //! assert_eq!(a, b);
 //! ```
 
+#[cfg(feature = "heap_size")]
+extern crate heapsize;
+
 use std::ascii::AsciiExt;
 #[cfg(iter_cmp)]
 use std::cmp::Ordering;
@@ -26,6 +31,7 @@ use std::str::FromStr;
 
 /// Case Insensitive wrapper of strings.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub struct UniCase<S>(pub S);
 
 impl<S> Deref for UniCase<S> {


### PR DESCRIPTION
Servo needs this because hyper stores UniCase into its own structs, and I want to support heapsize there.