### PR TITLE
Allow more conversions and impl Default

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -14,6 +14,11 @@ impl<S> Ascii<S> {
     pub fn new(s: S) -> Ascii<S> {
         Ascii(s)
     }
+
+    #[inline]
+    pub fn into_inner(self) -> S {
+        self.0
+    }
 }
 
 impl<S> Deref for Ascii<S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,10 +226,14 @@ macro_rules! into_impl {
     );
 }
 
-from_impl!(&'a str => &'a str);
+impl<S: AsRef<str>> From<S> for UniCase<S> {
+    fn from(s: S) -> Self {
+        UniCase::unicode(s)
+    }
+}
+
 from_impl!(&'a str => String);
 from_impl!(&'a String => &'a str; as_ref);
-from_impl!(String => String);
 
 into_impl!(&'a str);
 into_impl!(String);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 #[cfg(feature = "nightly")]
 extern crate test;
 
+use std::borrow::Cow;
 #[cfg(__unicase__iter_cmp)]
 use std::cmp::Ordering;
 use std::fmt;
@@ -232,11 +233,18 @@ impl<S: AsRef<str>> From<S> for UniCase<S> {
     }
 }
 
+from_impl!(&'a str => Cow<'a, str>);
+from_impl!(String => Cow<'a, str>);
+from_impl!(String => Box<str>);
 from_impl!(&'a str => String);
+from_impl!(Cow<'a, str> => String);
+from_impl!(Box<str> => String);
 from_impl!(&'a String => &'a str; as_ref);
 
 into_impl!(&'a str);
 into_impl!(String);
+into_impl!(Cow<'a, str>);
+into_impl!(Box<str>);
 
 #[cfg(__unicase__iter_cmp)]
 impl<T: AsRef<str>> PartialOrd for UniCase<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ mod unicode;
 pub struct UniCase<S>(Encoding<S>);
 
 /// Case Insensitive wrapper of Ascii strings.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Ascii<S>(S);
 
 /// Compare two string-like types for case-less equality, using unicode folding.
@@ -104,6 +104,12 @@ macro_rules! inner {
             &Encoding::Unicode(ref s) => &s.0,
         }
     });
+}
+
+impl<S: AsRef<str> + Default> Default for UniCase<S> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
 }
 
 impl<S: AsRef<str>> UniCase<S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,16 +235,13 @@ impl<S: AsRef<str>> From<S> for UniCase<S> {
 
 from_impl!(&'a str => Cow<'a, str>);
 from_impl!(String => Cow<'a, str>);
-from_impl!(String => Box<str>);
 from_impl!(&'a str => String);
-from_impl!(Cow<'a, str> => String);
-from_impl!(Box<str> => String);
+from_impl!(Cow<'a, str> => String; into_owned);
 from_impl!(&'a String => &'a str; as_ref);
 
 into_impl!(&'a str);
 into_impl!(String);
 into_impl!(Cow<'a, str>);
-into_impl!(Box<str>);
 
 #[cfg(__unicase__iter_cmp)]
 impl<T: AsRef<str>> PartialOrd for UniCase<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,17 @@ impl<S: AsRef<str>> UniCase<S> {
     }
 }
 
+impl<S> UniCase<S> {
+    /// Unwraps the inner value held by this `UniCase`.
+    #[inline]
+    pub fn into_inner(self) -> S {
+        match self.0 {
+            Encoding::Ascii(s) => s.0,
+            Encoding::Unicode(s) => s.0,
+        }
+    }
+}
+
 impl<S> Deref for UniCase<S> {
     type Target = S;
     #[inline]
@@ -209,10 +220,7 @@ macro_rules! into_impl {
     ($to:ty) => (
         impl<'a> Into<$to> for UniCase<$to> {
             fn into(self) -> $to {
-                match self.0 {
-                    Encoding::Ascii(Ascii(s)) => s,
-                    Encoding::Unicode(Unicode(s)) => s,
-                }
+                self.into_inner()
             }
         }
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[inline(never)]
     fn is_ascii(bytes: &[u8]) -> bool {
-        #[allow(unused)]
+        #[allow(unused, deprecated)]
         use std::ascii::AsciiExt;
         bytes.is_ascii()
     }

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 use self::map::lookup;
 mod map;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Unicode<S>(pub S);
 
 impl<S1: AsRef<str>, S2: AsRef<str>> PartialEq<Unicode<S2>> for Unicode<S1> {


### PR DESCRIPTION
This PR solves two issues I found when using `unicase` (which is very pleasant to work with other than these!).

- It adds a method `into_inner()` to `Ascii` and `UniCase`, allowing to retrieve the original string from these types. This could be done before via `Into`, but only if the inner type was `&str` or `String`. It wouldn't work e.g. for `Cow<'a, str>`.
- It adds more `From` and `Into` conversions, most notably for the lesser-known string types `Cow<'a, str>` ~~and `Box<str>`~~.
- It impls `Default` for the types in this crate where possible (using usually the empty string). I've only added this for completeness' sake and am willing to remove this if it's deemed harmful or unnecessary.

I haven't added any tests since I couldn't think of any. If you have any ideas, I'd be happy to add them.

I don't submit PRs very often so I'm apologizing in advance if I've missed anything.

EDIT:
I've dropped support for `Box<str>` for now. Adding it is complicated due to the support for Rust 1.3.0, which didn't have the `impl AsRef<str> for Box<str>` yet. We'd have to add a feature gate for this type. Would this be desirable?