### PR TITLE
provide const ASCII constructor for UniCase

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
-use super::Ascii;
+use super::{Ascii, Encoding, UniCase};
 
 impl<S> Ascii<S> {
     #[inline]
@@ -23,6 +23,16 @@ impl<S> Ascii<S> {
     #[cfg(not(__unicase__const_fns))]
     pub fn new(s: S) -> Ascii<S> {
         Ascii(s)
+    }
+
+    #[cfg(__unicase_const_fns)]
+    pub const fn into_unicase(self) -> UniCase<S> {
+        UniCase(Encoding::Ascii(self))
+    }
+
+    #[cfg(not(__unicase_const_fns))]
+    pub fn into_unicase(self) -> UniCase<S> {
+        UniCase(Encoding::Ascii(self))
     }
 
     #[inline]


### PR DESCRIPTION
Provide a way for const-constructed `UniCase` instances to avoid full Unicode case-folding when it's not necessary.

I'm currently working on closing sfackler/rust-phf#143 but I realized that the existing `unicode()` constructor will always perform Unicode case-folding which could be detrimental to projects like `mime_guess` which only need ASCII case folding but also need a const constructor.

Having a third constructor like this might be confusing to users who don't know the difference, so I'm fine dropping `UniCase::ascii()` and keeping `UniCase::is_ascii()` and `Ascii::into_unicase()` which still gives a `const` route to constructing a `UniCase` with ASCII encoding.