### PR TITLE
Forbid unsafe code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # unicase
 
-[![Build Status](https://travis-ci.org/seanmonstar/unicase.svg?branch=master)](https://travis-ci.org/seanmonstar/unicase)
+[![Build Status](https://travis-ci.org/seanmonstar/unicase.svg?branch=master)](https://travis-ci.org/seanmonstar/unicase) [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 [Documentation](https://docs.rs/unicase)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@
 //! assert_eq!(a, b);
 //! ```
 
+#[forbid(unsafe_code)]
+
 #[cfg(feature = "nightly")]
 extern crate test;
 


### PR DESCRIPTION
`#[forbid(unsafe_code)]` annotation makes rustc abort compilation if there are any unsafe blocks in the crate.

Presence of this annotation is picked up by tools such as [cargo-geiger](https://github.com/anderejd/cargo-geiger) and lets them ensure that there is indeed no unsafe code as opposed to something they couldn't detect (e.g. unsafe added via macro expansion, etc).

This also adds a badge advertising that unsafe code is forbidden. Being 100% safe is a desirable property for a crate and should be advertised. The badge currently links to Secure Code WG's community outreach repo, but I'm fine with changing the link or making the badge non-clickable.