### PR TITLE
Fix Unicode::eq to not equal when one side is a substring of the other

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,9 @@ mod tests {
         let c = UniCase::ascii("FoObAr");
 
         assert_eq!(a, b);
+        assert_eq!(b, a);
         assert_eq!(a, c);
+        assert_eq!(c, a);
         assert_eq!(hash(&a), hash(&b));
         assert_eq!(hash(&a), hash(&c));
         assert!(a.is_ascii());
@@ -368,12 +370,24 @@ mod tests {
         assert!(c.is_ascii());
     }
 
+
     #[test]
     fn test_eq_unicode() {
         let a = UniCase::new("στιγμας");
         let b = UniCase::new("στιγμασ");
         assert_eq!(a, b);
+        assert_eq!(b, a);
         assert_eq!(hash(&a), hash(&b));
+    }
+
+    #[test]
+    fn test_eq_unicode_left_is_substring() {
+        // https://github.com/seanmonstar/unicase/issues/38
+        let a = UniCase::unicode("foo");
+        let b = UniCase::unicode("foobar");
+
+        assert!(a != b);
+        assert!(b != a);
     }
 
     #[cfg(feature = "nightly")]

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -11,9 +11,25 @@ pub struct Unicode<S>(pub S);
 impl<S1: AsRef<str>, S2: AsRef<str>> PartialEq<Unicode<S2>> for Unicode<S1> {
     #[inline]
     fn eq(&self, other: &Unicode<S2>) -> bool {
-        self.0.as_ref().chars().flat_map(lookup)
-            .zip(other.0.as_ref().chars().flat_map(lookup))
-            .all(|(a, b)| a == b)
+        let mut left = self.0.as_ref().chars().flat_map(lookup);
+        let mut right = other.0.as_ref().chars().flat_map(lookup);
+
+        // inline Iterator::eq since not added until Rust 1.5
+        loop {
+            let x = match left.next() {
+                None => return right.next().is_none(),
+                Some(val) => val,
+            };
+
+            let y = match right.next() {
+                None => return false,
+                Some(val) => val,
+            };
+
+            if x != y {
+                return false;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #38 