### PR TITLE
Borrow - experimental sketch, DO NOT MERGE

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ use self::unicode::Unicode;
 
 mod ascii;
 mod unicode;
+mod noopt;
 
 /// Case Insensitive wrapper of strings.
 #[derive(Clone, Copy)]

--- a/src/noopt.rs
+++ b/src/noopt.rs
@@ -1,0 +1,54 @@
+use core::hash::Hash;
+use core::borrow::Borrow;
+use crate::*;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+/// Unicode case-insensitive wrapper without optimisation
+pub struct UniCaseNoOpt<S:?Sized>(S);
+
+impl<S> UniCaseNoOpt<S> {
+    pub fn new(s: S) -> Self { UniCaseNoOpt(s) }
+}
+impl<S:?Sized> UniCaseNoOpt<S> {
+    pub fn from_ref<'s>(s: &'s S) -> &'s UniCaseNoOpt<S> {
+        let x: &'s S               = s;
+        let y: &'s UniCaseNoOpt<S> = unsafe { core::mem::transmute(x) };
+        y
+    }
+}
+impl<S> From<S> for UniCaseNoOpt<S> {
+    fn from(s: S) -> UniCaseNoOpt<S> { UniCaseNoOpt(s) }
+}
+
+impl PartialEq for UniCaseNoOpt<str>
+{
+    fn eq(&self, other: &Self) -> bool {
+        Unicode(&self.0) ==
+        Unicode(&other.0)
+    }
+}
+impl Eq for UniCaseNoOpt<str> { }
+
+impl<S:?Sized> Hash for UniCaseNoOpt<S>
+where S: AsRef<str>, for <'u> UniCase<&'u S>: Hash
+{
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        Unicode(&self.0).hash(hasher)
+    }
+}
+
+impl<S:AsRef<str>> Borrow<UniCaseNoOpt<str>> for UniCase<S> {
+    fn borrow(&self) -> &UniCaseNoOpt<str> {
+        UniCaseNoOpt::from_ref(self.as_ref())
+    }
+}
+
+#[test]
+fn hashset() {
+    use std::collections::HashSet;
+
+    let mut hm: HashSet<UniCase<String>> = Default::default();
+    hm.insert(UniCase::new("ascii".to_string()));
+    assert!(hm.contains(UniCaseNoOpt::from_ref("Ascii")));
+}

--- a/src/unicode/map.rs
+++ b/src/unicode/map.rs
@@ -488,6 +488,7 @@ pub fn lookup(orig: char) -> Fold {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn lookup_consistency() {
     fn lookup_naive(orig: char) -> Fold {
         let single_char = match orig as u32 {
@@ -1993,3 +1994,6 @@ fn lookup_consistency() {
         }
     }
 }
+
+
+


### PR DESCRIPTION
In #22 I wrote

> An alternative would be to have a nonoptimised `UnicaseNoOpt<str>` which could be transparent, so that `&'s UnicaseNoOpt<str>` can be made from `&'s str` with one transmute.

This problem nerdsniped me.  The result is this branch.  Now we can do this:

```
    let mut hm: HashSet<UniCase<String>> = Default::default();
    hm.insert(UniCase::new("ascii".to_string()));
    assert!(hm.contains(UniCaseNoOpt::from_ref("Ascii")));
```

which is great!  My actual code is not really finished - no docs, probably style problems, and many trait impls etc. missing.  (It does pass miri, which is a thing I always check with `unsafe`)

But I thought I should share it.  If people like this direction, it could be tidied up.
