### PR TITLE
Fix hash prefix collision

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -127,6 +127,7 @@ impl<S: AsRef<str>> Hash for Ascii<S> {
         for byte in self.as_ref().bytes().map(|b| b.to_ascii_lowercase()) {
             hasher.write_u8(byte);
         }
+        hasher.write_u8(0xff);
     }
 }
 

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -59,8 +59,9 @@ impl<S: AsRef<str>> Hash for Unicode<S> {
         let mut buf = [0; 4];
         for c in self.0.as_ref().chars().flat_map(|c| lookup(c)) {
             let len = char_to_utf8(c, &mut buf);
-            hasher.write(&buf[..len])
+            hasher.write(&buf[..len]);
         }
+        hasher.write_u8(0xff);
     }
 }
 


### PR DESCRIPTION
For example `(UniCase::new("prefix"), UniCase::new("suffix"))` would always collide with `(Unicase::new("pre"), Unicase::new("fixsuffix"))`.

See also https://github.com/rust-lang/rust/issues/5257.

Don't see a great way to add a test case, because randomized hashers could still occasionally collide.