### PR TITLE
Add `UniCase::contains()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,23 @@ impl<S> UniCase<S> {
     }
 }
 
+impl<S1: AsRef<str>> UniCase<S1> {
+    /// Returns true if the given pattern matches a sub-slice of this string slice.
+    ///
+    /// Returns false if it does not.
+    #[inline]
+    pub fn contains<S2: AsRef<str>>(&self, pat: &UniCase<S2>) -> bool {
+        match (&self.0, &pat.0) {
+            (&Encoding::Ascii(ref x), &Encoding::Ascii(ref p)) => x.as_ref().contains(p.as_ref()),
+            (&Encoding::Unicode(ref x), &Encoding::Unicode(ref p)) => x.contains(p),
+            (&Encoding::Ascii(ref x), &Encoding::Unicode(ref p)) => Unicode(x.as_ref()).contains(p),
+            (&Encoding::Unicode(ref x), &Encoding::Ascii(ref p)) => {
+                x.contains(&Unicode(p.as_ref()))
+            }
+        }
+    }
+}
+
 impl<S> Deref for UniCase<S> {
     type Target = S;
     #[inline]

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -33,6 +33,49 @@ impl<S1: AsRef<str>, S2: AsRef<str>> PartialEq<Unicode<S2>> for Unicode<S1> {
     }
 }
 
+impl<S1: AsRef<str>> Unicode<S1> {
+    /// Returns true if the given pattern matches a sub-slice of this string slice.
+    ///
+    /// Returns false if it does not.
+    #[inline]
+    pub fn contains<S2: AsRef<str>>(&self, pat: &Unicode<S2>) -> bool {
+        let mut left = self.0.as_ref().chars().flat_map(lookup);
+        let mut pat = pat.0.as_ref().chars().flat_map(lookup);
+
+        match pat.next() {
+            Some(p0) => 'out: loop {
+                match left.next() {
+                    Some(e) if e == p0 => {
+                        let mut left = left.clone();
+                        let mut pat = pat.clone();
+
+                        loop {
+                            let p = match pat.next() {
+                                None => break 'out true,
+                                Some(p) => p,
+                            };
+
+                            let e = match left.next() {
+                                None => break 'out false,
+                                Some(e) => e,
+                            };
+
+                            if e != p {
+                                break;
+                            }
+                        }
+                    }
+                    Some(_) => {
+                        continue;
+                    }
+                    None => break false,
+                }
+            },
+            None => true,
+        }
+    }
+}
+
 impl<S: AsRef<str>> Eq for Unicode<S> {}
 
 #[cfg(__unicase__iter_cmp)]
@@ -197,5 +240,20 @@ mod tests {
     fn bench_simple_case_folding(b: &mut ::test::Bencher) {
         b.bytes = "στιγμας".len() as u64;
         b.iter(|| eq!("στιγμας", "στιγμασ"));
+    }
+
+    #[test]
+    fn test_contains() {
+        assert!(Unicode("A").contains(&Unicode("a")));
+        assert!(Unicode("AA").contains(&Unicode("a")));
+        assert!(Unicode("AAA").contains(&Unicode("aa")));
+        assert!(Unicode("BA").contains(&Unicode("a")));
+        assert!(Unicode("AB").contains(&Unicode("a")));
+        assert!(Unicode("BABABB").contains(&Unicode("babb")));
+
+        assert!(!Unicode("B").contains(&Unicode("a")));
+        assert!(!Unicode("BA").contains(&Unicode("aa")));
+        assert!(!Unicode("BA").contains(&Unicode("aa")));
+        assert!(!Unicode("BABABA").contains(&Unicode("babb")));
     }
 }


### PR DESCRIPTION
Adds `UniCase::contains()` to test if one unicode string contains another.

This somehow conflict with / workaround https://github.com/seanmonstar/unicase/issues/47