### PR TITLE
Make Unicode public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use core::hash::{Hash, Hasher};
 use core::ops::{Deref, DerefMut};
 use core::str::FromStr;
 
-use self::unicode::Unicode;
+pub use self::unicode::Unicode;
 
 mod ascii;
 mod unicode;

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -8,9 +8,13 @@ use self::map::lookup;
 mod map;
 
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Unicode<S>(pub S);
+pub struct Unicode<S>(pub (super) S);
 
 impl<S: AsRef<str>> Unicode<S> {
+    pub fn new(s: S) -> Self {
+        Self(s)
+    }
+
     pub fn to_folded_case(&self) -> String {
         self.0.as_ref().chars().flat_map(lookup).collect()
     }


### PR DESCRIPTION
Great library, I would like the Unicode struct to be public, I am making a case insensitive string that already stores whether it is ascii/unicode and therefore can bypass the Unicase enum.