### PR TITLE
Add #[repr(transparent)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ pub struct UniCase<S>(Encoding<S>);
 
 /// Case Insensitive wrapper of Ascii strings.
 #[derive(Clone, Copy, Debug, Default)]
+#[repr(transparent)]
 pub struct Ascii<S>(S);
 
 /// Compare two string-like types for case-less equality, using unicode folding.

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -8,6 +8,7 @@ use self::map::lookup;
 mod map;
 
 #[derive(Clone, Copy, Debug, Default)]
+#[repr(transparent)]
 pub struct Unicode<S>(pub S);
 
 impl<S: AsRef<str>> Unicode<S> {


### PR DESCRIPTION
This makes unsafe casts between `T` and `Ascii<T>` possible, which could be used to hack `Borrow` support: #22 