### PR TITLE
[feat] add support for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,10 @@ version_check = "0.9"
 
 [features]
 nightly = []
+serde = ["dep:serde"]
+
+[dependencies]
+serde = { version = "1.0.210", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.128"

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -133,6 +133,13 @@ impl<S: FromStr> FromStr for Ascii<S> {
     }
 }
 
+impl<S: AsRef<str>> From<S> for Ascii<S> {
+    #[inline]
+    fn from(s: S) -> Ascii<S> {
+        Ascii(s)
+    }
+}
+
 impl<S: AsRef<str>> Hash for Ascii<S> {
     #[inline]
     fn hash<H: Hasher>(&self, hasher: &mut H) {
@@ -193,6 +200,18 @@ mod tests {
         assert_eq!(c, Ascii("baz"));
         assert_eq!(c, Ascii("Baz"));
         assert_eq!(c, Ascii("Baz".to_string()));
+
+        let mut map = std::collections::HashMap::<Ascii<&str>, i32>::new();
+        map.insert("abc".into(), 2);
+        assert_eq!(map.get(&"abc".into()), Some(&2));
+        assert_eq!(map.get(&"ABC".into()), Some(&2));
+        assert_eq!(map.len(), 1);
+        // test if the value is updated correctly using a different cased key
+        let old = map.insert("ABC".into(), 3);
+        assert_eq!(old, Some(2));
+        assert_eq!(map.get(&"abc".into()), Some(&3));
+        assert_eq!(map.get(&"ABC".into()), Some(&3));
+        assert_eq!(map.len(), 1);
     }
 
     #[cfg(__unicase__iter_cmp)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,19 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
+impl<S> serde::Serialize for UniCase<S>
+where
+    S: serde::Serialize,
+{
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+    where
+        T: serde::Serializer,
+    {
+        inner!(self.0).serialize(serializer)
+    }
+}
+
 impl<S: AsRef<str> + Default> Default for UniCase<S> {
     fn default() -> Self {
         Self::new(Default::default())
@@ -456,6 +469,18 @@ mod tests {
         assert_eq!(b, UniCase::new("foobar".to_string()));
         assert_eq!(b, a);
         assert_ne!(b, UniCase::new("baz"));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serialize() {
+        let a = UniCase::new("foobar");
+        let json = serde_json::to_string(&a).unwrap();
+        assert_eq!(json, "\"foobar\"");
+
+        let a = UniCase::new("FOOBAR");
+        let json = serde_json::to_string(&a).unwrap();
+        assert_eq!(json, "\"FOOBAR\"");
     }
 
     #[cfg(__unicase__iter_cmp)]


### PR DESCRIPTION
Scenario: One may want to deserialize into a `HashMap<String, String>` from, say, a config file containing a map with arbitrary keys. There's a `config-rs` crate for this, but due to https://github.com/mehcode/config-rs/issues/531, the deserialized keys are always converted to lowercase. The consequence is catastrophic: for a `Map<user_id, priority>` where `user_id` might contain upper cased letters, anyone forgetting to add a `.to_ascii_lowercase()` will find `None` from the hash map.

Many crates also have a special `serde` feature for serialize/deserialize using `serde_json` or other similar libraries built upon the `serde` crate. So maybe we should add this feature into unicase as well.