### PR TITLE
Version bump to v2.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicase"
-version = "2.7.0" # don't forget to update html_root_url
+version = "2.8.0" # don't forget to update html_root_url
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 description = "A case-insensitive wrapper around strings."
 repository = "https://github.com/seanmonstar/unicase"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(test, deny(missing_docs))]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/unicase/2.7.0")]
+#![doc(html_root_url = "https://docs.rs/unicase/2.8.0")]
 #![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(all(__unicase__core_and_alloc, not(test),), no_std)]
 


### PR DESCRIPTION
Hi, I'm working on Nushell and we have [some code](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/casing.rs#L43-L45) where we'd like to use the `to_folded_case` functionality introduced in 07f81c1. However, there's not been a release since this commit, so I would appreciate if you would be able to accept this version bump!