### PR TITLE
Check for ASCII in `from` impl as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,11 +261,7 @@ macro_rules! into_impl {
 
 impl<S: AsRef<str>> From<S> for UniCase<S> {
     fn from(s: S) -> Self {
-        if s.as_ref().is_ascii() {
-            UniCase::ascii(s)
-        } else {
-            UniCase::unicode(s)
-        }
+        UniCase::new(s)
     }
 }
 


### PR DESCRIPTION
This addresses https://github.com/seanmonstar/unicase/issues/76 which reports that there is an inconsistency between `UniCase::new()` and `UniCase::from()` for ASCII strings where the latter doesn't check for encoding. Also added a test and modified an existing one that should fail without this fix.