### PR TITLE
Flag all alloc usage behind a new, default-enabled feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "unicase"
-version = "2.9.0" # don't forget to update html_root_url
+version = "3.0.0" # don't forget to update html_root_url
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 description = "A case-insensitive wrapper around strings."
 repository = "https://github.com/seanmonstar/unicase"
@@ -17,4 +17,7 @@ exclude = [
 ]
 
 [features]
+default = ["alloc"]
+
+alloc = []
 nightly = []

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "alloc")]
 use alloc::string::String;
+
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
@@ -73,6 +75,7 @@ impl<S: fmt::Display> fmt::Display for Ascii<S> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<S1: AsRef<str>> PartialEq<Ascii<S1>> for String {
     #[inline]
     fn eq(&self, other: &Ascii<S1>) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,15 @@ extern crate std;
 #[cfg(feature = "nightly")]
 extern crate test;
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 
+#[cfg(feature = "alloc")]
 use alloc::borrow::Cow;
+
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
@@ -135,6 +140,7 @@ impl<S: AsRef<str>> UniCase<S> {
     ///
     /// Unicode Case Folding is meant for string storage and matching, not for
     /// display.
+    #[cfg(feature = "alloc")]
     pub fn to_folded_case(&self) -> String {
         match self.0 {
             Encoding::Ascii(ref s) => s.0.as_ref().to_ascii_lowercase(),
@@ -238,6 +244,7 @@ impl<S> From<Ascii<S>> for UniCase<S> {
     }
 }
 
+#[cfg(feature = "alloc")]
 macro_rules! from_impl {
     ($from:ty => $to:ty; $by:ident) => (
         impl<'a> From<$from> for UniCase<$to> {
@@ -265,14 +272,27 @@ impl<S: AsRef<str>> From<S> for UniCase<S> {
     }
 }
 
+#[cfg(feature = "alloc")]
 from_impl!(&'a str => Cow<'a, str>);
+
+#[cfg(feature = "alloc")]
 from_impl!(String => Cow<'a, str>);
+
+#[cfg(feature = "alloc")]
 from_impl!(&'a str => String);
+
+#[cfg(feature = "alloc")]
 from_impl!(Cow<'a, str> => String; into_owned);
+
+#[cfg(feature = "alloc")]
 from_impl!(&'a String => &'a str; as_ref);
 
 into_impl!(&'a str);
+
+#[cfg(feature = "alloc")]
 into_impl!(String);
+
+#[cfg(feature = "alloc")]
 into_impl!(Cow<'a, str>);
 
 impl<T: AsRef<str>> PartialOrd for UniCase<T> {

--- a/src/unicode/mod.rs
+++ b/src/unicode/mod.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "alloc")]
 use alloc::string::String;
+
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 
@@ -9,6 +11,7 @@ mod map;
 pub struct Unicode<S>(pub S);
 
 impl<S: AsRef<str>> Unicode<S> {
+    #[cfg(feature = "alloc")]
     pub fn to_folded_case(&self) -> String {
         self.0.as_ref().chars().flat_map(lookup).collect()
     }


### PR DESCRIPTION
### Problem
Some projects (specifically embedded projects) wish to avoid being forced into selecting a global allocator.  By declaring `extern crate alloc`, this crate forces those projects to configure a global allocator, even if they don't use any of the code which requires alloc types.

Example linking error caused by attempting to use this crate in an embedded  project I'm working  on:
```
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait
```

Note that this linking error occurs regardless of how this crate is used -- e.g. `assert!(UniCase::new("a") == UniCase::new("A"));` does not require an allocations.

### Solution
* Added a new feature to the crate named `alloc` and made it a default-enabled feature for backwards compatibility
* Made all alloc-related functionality conditional on the `alloc` feature being enabled
* Bumped the version from 2.8.1 to 2.9.0 since this is a backwards compatible feature release.

Projects which wish to remove the alloc requirement will now be able to consume this crate by declaring their dependency as 
```
unicase = { version = "2", default-features = false }
```
