### PR TITLE
add top-level cmp and cmp_ascii functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,25 @@ pub fn eq_ascii<S: AsRef<str> + ?Sized>(left: &S, right: &S) -> bool {
     Ascii(left) == Ascii(right)
 }
 
+/// Compare two string-like types for case-less ordering, using unicode folding.
+///
+/// Equivalent to `UniCase::new(left).cmp(&UniCase::new(right))`.
+///
+/// Note: This will perform a scan for ASCII characters before doing the
+/// the comparison. See `UniCase` for more information.
+#[inline]
+pub fn cmp<S: AsRef<str> + ?Sized>(left: &S, right: &S) -> Ordering {
+    UniCase::new(left).cmp(&UniCase::new(right))
+}
+
+/// Compare two string-like types for case-less ordering, ignoring ASCII case.
+///
+/// Equivalent to `Ascii(left).cmp(&Ascii(right))`.
+#[inline]
+pub fn cmp_ascii<S: AsRef<str> + ?Sized>(left: &S, right: &S) -> Ordering {
+    Ascii(left).cmp(&Ascii(right))
+}
+
 #[derive(Clone, Copy, Debug)]
 enum Encoding<S> {
     Ascii(Ascii<S>),


### PR DESCRIPTION
these mirror the eq and eq_ascii functions, but return an Ordering and not a bool.

this is useful for sorting elements using the sort_by function, as previously this would be quite annoying:

```rs
// previously
strings.sort_by(|s1, s2| UniCase::new(s1).cmp(&UniCase::new(s2)));
// now
strings.sort_by(|s1, s2| unicase::cmp(s1, s2));
```

using the sort_by_key function doesn't work as well, as it has to return owned data, which means i would have to unnecessarily clone the string.

i personally use sorting with unicase quite a bit (for example [in my music player](https://github.com/m4rch3n1ng/maym/blob/7382f962b41683f923fa1b6d50e9b9bc0739f94c/src/config.rs#L172-L176), as well as a few currently private projects), and this small wrapper function would improve the readability quite a bit in a lot of these cases.